### PR TITLE
Expand XirisBot documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,374 +1,108 @@
 # XirisBot
 
-A plugin-driven automation framework for EverQuest on EQEMU servers, designed to orchestrate multi-character raid behavior with precision, flexibility, and minimal manual intervention.
+XirisBot is an INI-driven MacroQuest bot framework for EverQuest emulator raids. It coordinates class combat routines, healing, curing, buffing, movement, burns, pets, looting, and encounter-specific reactions across a multi-box crew.
 
-## Table of Contents
+The project is built for the RoF2-era MacroQuest environment used by this repository. It assumes a trusted private group or raid: many commands are intentionally accepted through tells, group chat, raid chat, and DanNet messages.
 
-* 🧠 Overview
-* 🚀 Key Features
-* ⚙️ Technology Stack
-* 📦 Architecture & Code Structure
-* 🔧 Installation & Configuration
-* 🎮 Usage & Commands
-* 📈 Impact & Metrics
-* 🤝 Contributing
-* 📜 License & Contact
+## Start here
 
-## 🧠 Overview
+1. Read [Installation](docs/installation.md) and load the required plugins.
+2. Create or copy the character INI described in [Configuration](docs/configuration.md).
+3. Start one character with `/mac xiris_bot` and resolve any initialization errors.
+4. Start the crew and create the recommended [Hotkeys](docs/hotkeys.md).
+5. Use the [Command reference](docs/commands.md) when building raid or character-specific controls.
 
-XirisBot empowers raid leaders and players on EQEMU servers (notably EQTitan) to automate combat routines, healing, buffing, looting, navigation, and event responses across multiple characters. By leveraging MacroQuest2 plugins and INI-driven templates, XirisBot adapts to any class role, ensuring reliable performance during high-pressure encounters and scripted raid pulls.
+## Minimal quick start
 
-## 🚀 Key Features
+The loader accepts three tank names, the normal tank heal threshold, and optional auto-assist settings:
 
-* Class-specific macros for every EverQuest role (tank, healer, DPS, support)
-* INI-based configuration for granular control over behavior and thresholds
-* Plugin orchestration with MQ2Dannet, MQ2Nav, MQ2Medley, MQ2WorstHurt, and custom includes
-* Hotkey-driven commands for raid-wide coordination (buffs, debuffs, heals, loots)
-* Event library system for scripted responses to boss mechanics and pull sequences
-* Automatic follow-distance and pathfinding support via MQ2Nav integration
-* Modular design enabling rapid extension and custom script injection
-
-## ⚙️ Technology Stack
-
-* Core scripting language: MQ2 Macro (`.mac`)
-* Shared libraries and includes: C++–style include files (`.inc`)
-* Configuration format: INI files (`.ini`)
-* Plugin dependencies:
-  * MQ2Dannet for inter-bot communication
-  * MQ2Nav for navigation and pathfinding
-  * MQ2Medley for automated bard things
-  * MQ2WorstHurt for priority-based healing
-* Version control and CI: Git, GitHub Actions (future CI suggested)
-
-## 📦 Architecture & Code Structure
-
-A high-level overview of the folder layout and key responsibilities:
-
-| Folder / File        | Purpose                                                  |
-|----------------------|----------------------------------------------------------|
-| `xiris_common/`      | Core includes for casting, healing, buffing, debuffing, commands |
-| `xiris_class_ini/`   | Base INI templates per class to standardize role behavior |
-| `xiris_trade_ini/`   | Loot rules and trade-in configurations                   |
-| `xiris_bot.mac`     | Entrypoint macro that loads class macros based on active INI |
-| `bot_*.mac`          | Class-specific macro logic (e.g., `bot_pal.mac`, `bot_rog.mac`) |
-| `*.ini`              | Character-specific overrides for macros and thresholds   |
-| [`README.md`](https://README.md) | This document                                  |
-| `.github/`, `.vscode/` | Repository and editor configuration                   |
-
-ASCII flow of macro loading and initialization:
-
-```
-[Start]
-   ↓
-xiris_bot.mac reads INI → determines class
-   ↓
-Include core libraries (xiris_common)
-   ↓
-Load class macros (bot_<class>.mac)
-   ↓
-Enter heartbeat loop
+```text
+/mac xiris_bot MainTank SecondTank ThirdTank 85 "FALSE,98"
 ```
 
-## 🔧 Installation & Configuration
+If arguments are omitted, XirisBot reads its defaults from the active character INI:
 
-1. Clone the repository into your MacroQuest2 `Macros` directory.
-2. Ensure required MQ2 plugins are installed and loaded:
-   * [`MQ2Dannet.dll`](https://MQ2Dannet.dll)
-   * [`MQ2Nav.dll`](https://MQ2Nav.dll)
-   * [`MQ2Medley.dll`](https://MQ2Medley.dll)
-   * [`MQ2WorstHurt.dll`](https://MQ2WorstHurt.dll)
-3. Copy and customize the INI templates from `xiris_class_ini/` into your character folder.
-4. Adjust thresholds (health, mana, cooldowns, follow distance) in your `bot_<class>_Charname.ini`.
-5. Launch EverQuest with MacroQuest2. In-game, execute:
-   ```
-   /macro xiris_bot
-   ```
-
-
-
----
-## 🎮 Usage & Commands
-
-Refer to the INI comments for full command bindings and customization.
-
-#### Macroquest2
-Xiris bot recommends the ROF2 EMU build of MQ2 from MMOBugs. As of Spring 2022 it was decided that this would be free, and no longer require a mmobugs.com subcscription. To run the build you will need to go to [MMOBugs](https://www.mmobugs.com/) and create an account. Once the account is created, go to the forums, and find the EverQuest Server Emulator section. In this section there is a thread: [MMOBugs MQ2 Installation for Emulator Clients - Download Links and Instructions](https://www.mmobugs.com/forums/index.php?threads/mmobugs-mq2-installation-for-emulator-clients-download-links-and-instructions.29682/) At the top of the thread you will see download links, and the first 1) is the ROF2 build with the lastest MQ2 codebase. Grab the setup version, and install wherever you want.
-
-##### Plugins
-XirisBot requires several plugins that are not standard to the E3 builds you are used to. These are more modern plugins than what were generally avaialable. These are powerful and important plugins that will greatly enhance the experience once you become used to them
-###### MQ2Dannet
-DanNet was created by Dannuic, one of the main contributers to MQ2 and MQNext. This is a replacement for EQBC that provides direct access to any toon from any other toon via queries and observers. The documentation is found at [MQ2Dan on Github](https://github.com/dannuic/MQ2Dan) While it is not required that you know the details of this plugin, it will be helpful to learn the command syntax since it totally replaces EQBC - specifically the 1:1 replacements for common commands in EQBC. Forexample if in EQBC you'd use `/bcaa` instead you'd use `/dga` and instead of `/bct` you'd use `/dt`  Once you get used to it, it works the same. *IMPORTANT* By Default, MQ2Dannet uses fully qualified names as chatsender. ie: EQTitan.Xiris, to preserve backwards compatibility in EVENTs, run `/dnet fullnames off` which will make it so chatsender only sends the character name. Note: this command is now always run in the xbot_initialize (xiris_common.inc) on load.
-###### MQ2Debuffs
-Required for curing of group/raid. Probably also used with E3. Added it here for clarity.
-###### MQ2Nav
-MQ2Nav is a game-changing quality of life improvement. Instead of having your toons `/stick` to you, you can have them follow you using MQ2Nav that *automatically generates paths* to the target (you) or you could tell your entire raid to navigate to a target or predefined (by you) waypoint. [MQ2Nav on Github](https://github.com/brainiac/MQ2Nav/wiki) The wiki link will give detail usage. Xiris bot has several built in commands that require MQ2Nav to function ex: `/rs FollowMe /type|NAV`
-The navigation paths are determined by the plugin parsing a pre-generated zone mesh file. These navmesh files are found in the */Macroquest2/MQ2Nav* folder. They do not come by default with the compile, it is best to grab a premade package of files from [MQ2Mesh](https://mqmesh.com/) grab each package from the expansions listed (you do not need anything past OOW at this point) and extract the zip files to the MQ2Nav folder.
-###### MQ2Medley
-MQ2Medley replaces MQ2Twist for bard songs. This is because medley allows for queing new songs without restarting the twist, which is invaluable for self buffs, casting debuffs, casting nukes, etc. This will require setting up 'medleys' in your characters macroquest.ini file found in the root of your macroquest folder. 
-An example would be for the bard Achlys, */Macroquest2/EQTitan_Achlys.ini* [Wiki Guide](https://www.redguides.com/wiki/MQ2Medley)
+```text
+xiris_class_ini/BOT_<CLASS>_<Character>.ini
 ```
-[MQ2Medley]
-Delay=3
-Quiet=1
-Debug=0
 
-[MQ2Medley-tank]
-song1=Niv's Harmonic^18^1
-song2=Guardian Rhythms^18^1
-song3=Verse of Vesagran^18^1
-song4=War March of Muram^18^1
-song5=Psalm of Mystic Shielding^18^1 
+Example:
+
+```text
+xiris_class_ini/BOT_CLR_Xanshia.ini
 ```
-~~###### MQ2Melee
-Standard plugin generally. Used to handle the auto skills portion of meleeing, such as backstab/frenzy/kick etc. Note: if there is a desire, I can eliminate this and run it entirely within the macro.~~ 
-###### MQ2WorstHurt
-Plugin available in modern compiles that replacing for loops looking at group, and xtarget members hp points. See https://www.redguides.com/wiki/MQ2WorstHurt
-#### Everquest Build
-While Xiris bot would work with UF, the MQ2 Plugin requirements mean that only the ROF2 build of Everquest will work properly without a huge degredation of service and code changes.
-### Loading
-#### xiris_bot.mac
-This macro will load the class specific macro. Think of this as a bootstrapper, or loader. The best way to accomplish loading the macro on all toons is to create a single hotkey on your tank wit the line: ```/dgza /mac xiris_bot ${Me.Name} Xiria Xirea 85```  
-The arguments in that command can be described as
-1. `/dgza` this is a MQ2Dannet command that *everyone in zone do this command*
-2. `/mac xiris_bot` load this macro
-3. `${Me.Name}` This toon is MT - note this could be a hard set name, however, in a hotkey this will resolve to whomever clicked the hotkey. Allows for easy copying of UIs and hotkeys between your tanks and not having to edit every hotkey.
-4. `Xiria Xirea` These toons are ST and TT
-5. `85` This is the default healpoint for the MT
-#### MQ2Autologin
-This build recommends using an MQ2Autologin script to load your raid. To create the batch file, open up notepad (or notepad++, which is recommended) and for each of your characters you'd be loading in:
-`ECHO Loading 1 [Xiris] `
-`START "" "C:\Program Files (x86)\EQ\EQ_INI\RoF2_1.lnk" patchme /login:myaccountname TIMEOUT /T 10 /NOBREAK`
-You should end up with 54 entries in the file, which you should then save as RAID.bat or some other name you'd remember.
-Additionally, if you note, the path does not link directly to the eqgame.exe but instead a shortcut link. This just makes it easier to change the path to the .exe file without editing the batch file later. Additionally, you should also create a shortcut link *to every character you have* while it is not required at this point, this will allow you to load a single toon easily.
 
-#### CPU Affinity
-To achieve the best performance, you will have to run a PowerShell script (triggerable via batch file) to set the affinity of every eqgame.exe instance to a core. See `eqaff.bat` and `_AFFINITY.bat` inside the distribution zip file.
+To start every connected character in the current zone from a tank:
 
-### INI Files & Class Macros
-XirisBot individual character properties are defined in a INI file, with the naming convention `./Macros/xiris_settings_character/BOT_ClassShortName_CharName.ini` or for example `BOT_BER_Ophidia.ini` In each of these INI files there are many sections, which tell XirisBot how the character should behave such as, disciplines, AA, nukes, debuffs, etc. See any of the ini files for examples. Most classes have their own class macros, except for pure Endurance based melee (MNK, ROG, BER) which share bot_melee.mac. Please note that **I personally don't usually run a macro on the MT**
-#### Bard
-**bot_brd.mac** Melee class, with support for nuking, dotting, debuffing, and singing.
-#### Cleric
-**bot_clr.mac** Priest class, with support for healing, buffing, debuffing, nuking, curing, and healing.
-#### Druid
-**bot_dru.mac** Priest class, with support for healing, buffing, debuffing, nuking, dotting, curing, and healing. 
-#### Enchanter
-**bot_enc.mac** Caster class, with support for debuffing, buffing, nuking, dotting, and charming.
-#### Magician
-**bot_mag.mac** Caster class, with support for pets, buffing, debuffing, and nuking.
-#### Necromancer
-**bot_nec.mac** Caster class, with support for pets, buffing, debuffing, nuking, and dotting.
-#### Paladin
-**bot_pal.mac** Tank class, with support for buffing, stunning, healing, and offtanking.
-#### Ranger
-**bot_rng.mac** Melee class, with support for healing, buffing, debuffing, nuking, and healing.
-#### Shadowknight
-**bot_shd.mac** Tank class, with support for nuking, lifetapping, debuffing, dotting, and offtanking [recommend as MT during trash clearing].
-#### Shaman
-**bot_shm.mac** Priest class, with support for healing, buffing, debuffing, nuking, dotting, curing, and healing. 
-#### Warrior
-**bot_war.mac** Tank class, offtanking.
-#### Wizard
-**bot_wiz.mac** Caster class, with support for nuking, quick nuking, ae nuking
-#### Endurance Melee (Monk, Rogue, Berserker)
-**bot_melee.mac** Standard melee class macro
+```text
+/dgza /mac xiris_bot ${Me.Name} Xiria Xirea 85 "FALSE,98"
+```
 
-## Commands
-While there are *many* commands built into XirisBot, only a few are generally needed to start. It is recommended that you create hotkeys for these however it is comfortable to use, primarily on your MT. Note that these examples use `/rs` which is raidsay, you could also do this with `/dgt` which tells all toons online the same thing. A full command list will follow under the detailed library descriptions.
+## Everyday controls
 
-### Attack
-Hotkey that is used on the MT to call assist on the MT's current target, and has the MT attack the target as well. 
-`/multiline ; /rs KillMob ${Target.ID} "${Target.Name}" ${Time.Time24} ; /attack on`
+```text
+/rs KillMob ${Target.ID} "${Target.CleanName}" ${Time.Time24}
+/rs BackOff
+/rs FollowMe /type|NAV
+/rs NavStop
+/rs doRaidBuffs ALL
+/rs DebuffTarget ${Target.ID}
+/rs BurnOnAll
+```
 
-### Buffing
-Hotkey or command that is used to tell all available buffers to walk through the raid buffing each group (and single target buff defined memembers with special buffs)
-`/rs doraidbuff ALL`
-Note: You should create a spell set named "buff" that holds the buff spell setup, and "default" for your default setup.
+These are message-driven commands. Sending the text through a supported channel causes each running macro that registered the event to handle it. See [Commands](docs/commands.md) for scopes, arguments, and targeted examples.
 
-### Debuffing
-Hotkey or command that is used to tell all available debuffers to debuff the current target. Note: usually debuffers will also debuff on the Attack call, but sometimes you want to predebuff a target (if its rooted like in Tacvi) or force them to re-debuff all at the same time.
-`/rs DebuffTarget ${Target.ID}`
+## Supported class macros
 
-### Curing
-Curing becomes *vitally* important in Txevu+ As such there are several commands to force curing. Note: for the majority of the time, all toons will request the appropriate cure from their assigned curers. However, there are times when you want to force it.
-1. Cure All Raid Groups `/dgt cureGroupPoison 45` this example tells all curers to look at their groups and to attempt to cure at least 45 poisons counters. Note that the curer will inspect the curee before casting and if its not required will skip that curee. The valid commands here are `cureGroupPoison` `cureGroupDisease` `cureGroupCurse`
-2. AutoCure the MT `/dt MyCleric autoCureMT TRUE` this tells a toon named MyCleric to watch the MT and cure anything that lands on her that is cureable. Note since we can set different MTs per cleric (by telling a cleric or whomever `/dt changeMT newMT`) you can set multiple clerics to autocure multiple 'MTs'
+| Class | Macro | Major capabilities |
+|---|---|---|
+| Bard | `bot_brd.mac` | Medley, melee, nukes, DoTs, debuffs |
+| Beastlord | `bot_bst.mac` | Pet, melee, spells, attack buffs |
+| Cleric | `bot_clr.mac` | Healing, curing, buffs, rez, battle-cleric mode |
+| Druid | `bot_dru.mac` | Healing, curing, buffs, nukes, DoTs |
+| Enchanter | `bot_enc.mac` | Debuffs, buffs, charm, runes, pet |
+| Magician | `bot_mag.mac` | Pet, buffs, nukes, AE nukes |
+| Necromancer | `bot_nec.mac` | Pet, nukes, DoTs, feign death |
+| Paladin | `bot_pal.mac` | Tanking, healing, stuns, offtanking |
+| Ranger | `bot_rng.mac` | Melee, spells, self/group healing |
+| Shadowknight | `bot_shd.mac` | Tanking, lifetaps, DoTs, feign death |
+| Shaman | `bot_shm.mac` | Healing, curing, buffs, slows, DoTs |
+| Warrior | `bot_war.mac` | Tanking, disciplines, offtanking |
+| Wizard | `bot_wiz.mac` | Nukes, quick nukes, AE nukes, aggro reduction |
+| Berserker, Monk, Rogue | `bot_melee.mac` | Shared endurance-melee routine |
 
-### Healing
-Healing is usually handled automatically. 
-Specifically healers, in the default healmode (2, this is settable in the ini file) will attempt to heal their MT, themselves, and then their group, in that order. You can set different MTs for various healers and they will watch that MT and that MT only. MTs do not need to be in the group to be healed.
-### Looting
-Looting is fairly complex, and is based on  xiris_loot_list.ini (found in the /xiris_common subfolder in your macro folder)
-I have an Excel spreadsheet that generates the ini file for myself through Excel macros, but you could do so manually as well. Loot is not auto added to the ini file - an entry must be created.
-`/dt Looter looton ALL` will tell looter, Looter to loot ALL items as defined as lootable in the ini file
-`/dt Looter looton QUEST` will tell looter, Looter to loot only QUEST items as defined as lootable in the ini file
+`xiris_bot.mac` is only the loader. It selects `bot_<CLASS>.mac`, with BER/MNK/ROG routed to `bot_melee.mac`.
 
-Loot INI file layout, arguments seperated by pipes
-*Loot1=Minor Muramite Rune|QUEST|*|*|!|Aergia|F*
-- Item Name 
-- Type (VENDOR|TRADE|QUEST) Currently only QUEST is handled differently, the rest is combined under the ALL flag.
-- Count (* or integer)
-- Class (* or CSV ClassShortName BER,CLR etc)
-- Not ToonName or ! for any toon
-- Only Tooname or * for everyone
-- Beep T or F if the looter should emit a beep if item is found
+## Documentation
 
-### Movement
-Movement can be achieved either using MQ2Nav or MQ2MoveUtils(stick) with MQ2Nav far preferable. Note in some cases Nav will fail if the toon is on an unnavigable surface (stuck near wall, etc) and you may have to either manually move them or tell them to stick to you.
-`/rs FollowMe /type|NAV` or `/rs FollowMe /type|STICK`
+- [Installation and prerequisites](docs/installation.md)
+- [Character configuration](docs/configuration.md)
+- [Command reference](docs/commands.md)
+- [Recommended hotkeys](docs/hotkeys.md)
+- [Architecture and extension points](docs/architecture.md)
+- [Troubleshooting](docs/troubleshooting.md)
 
-Additionally you can tell toons to navigate to waypoints which you had already defined (the command `/nav recordwaypoint WaypointName`)
-`/rs NavToWP WaypointName`
+## Repository layout
 
-### Offtanking
-To tell a toon to offtank (and currently only plate classes listen for this) the command is
-`/dt ToonName offtankon` and the offtank will attempt to offtank any aggrod mob that isn't currently hitting a tank. However due to lag or other issues sometimes this is not 100% reliable. It works mostly though. `/dt ToonName offtankoff` will cancel offtanking
+| Path | Purpose |
+|---|---|
+| `xiris_bot.mac` | Loader and class router |
+| `bot_*.mac` | Class main loops and class-specific behavior |
+| `xiris_common/*.inc` | Shared behavior libraries |
+| `xiris_common/xiris_events_raid_*.inc` | Zone and encounter reactions |
+| `xiris_class_ini/` | Per-character behavior configuration |
+| `xiris_common/*.ini` | Shared definitions, loot rules, exclusions, and encounter data |
+| `xiris_trade_ini/` | Trade-skill configuration |
 
-## Detailed Library Descriptions
+## Safety notes
 
-### Overview
-XirisBot shares libraries for all class variants. These files are found in the xiris_common sub folder.
+- Test new INI entries on one character before deploying them raid-wide.
+- Keep a `BackOff` and `NavStop` hotkey available at all times.
+- Verify the target before broadcasting `KillMob`, `DebuffTarget`, charm, or movement commands.
+- Encounter includes can move characters or react to emotes automatically. Review the relevant raid include before a first attempt.
+- Character INIs in this repository contain crew-specific names and spell lineups. Treat them as examples, not portable defaults.
 
-### xiris_buffing.inc
-#### Overview
-XirisBot buffing handlers. The library reads the buff settings in each character ini file to determine what buffs the character can cast (if any). There are several classes of buffs:
-1. OutOfCombat (OOC) Buffs - These are buffs such as Symbol/Haste/etc which you would generally cast out of combat
-2. SingleTarget (ST) Buffs  - These are buffs that effect a single target, like Panoply of Vie, or Guard of Earth
-3. Combat (CMBT) Buffs - These are buffs that are (auto) cast during a fight, eg: Spirit of Jaguar
-#### Requirements
-mq2cast, mq2dannet
-#### Events
-1. `/dgt DoRaidBuffs *ALL*` Will have all buffers walk through the raid and cast all designated buffs (OOC and ST).
-2. `/dgt DoCharBuffs *CharName*` Will have all buffers target the specified character, and cast all buffs (note: most buffs are group buffs)
-3. `/dgt RemoveBuff *BuffName*` Will find and remove that buff from all characters
-4. `/dgt RemoveAllBuffs` Will remove all buffs from all characters
+## Contributing
 
-
-### xiris_casting.inc
-#### Overview
-XirisBot casting handler. The library reads the casting (NUKE, AE NUKE, QUICK NUKE, DOT, FAST DOT, and STUN) settings in each character ini file to determine what the character can cast (if any)
-#### Requirements
-mq2cast, mq2dannet
-#### Events
-1. `/dgt SetResistTypes *fire|poison|magic|etc*` Sets the resist types that will be cast. Can be used to limit to only say... fire and magic on Ture (`/dgt setresisttypes fire|magic`)
-2. `/dgt SetUseFastOnly *on|off` Turning this on will have wizards (and other classes if they have any defined QNUKE) only use the QNUKE entries instead of normal NUKE
-
-### xiris_charm.inc
-#### Overview
-XiristBot charm handler. The library reads the charming (CHARM) settings in the Bard, Necromancer, and Enchanter ini files. Note this is generally untested as there is very little need to charm things (other than OMM)
-#### Requirements
-mq2cast, mq2dannet
-#### Events
-1. `/dt charname CharmNPCByID *NPCID*` Tells toon charname to charm the npc with the id given
-2. `/dt charname CharmNPCByName *NPCName*` Tells toon charname to charm the npc with the name given
-3. `/dt charmOn` Allows charming, must be called before telling a toon to charm with the above commands
-4. `/dt charmOff` Disables charming.
-
-### xiris_common.inc
-#### Overview
-XirisBot common handlers. Contains the links to all other includes. Has the common functions for all the class macros, and serves to kick off all initializations.
-#### Requirements
-mq2cast, mq2dannet, mq2exchange, mq2melee
-#### Events
-1. `/dgt KillMob ${Target.ID} "${Target.Name}" ${Time.Time24}` Directs everyone to kill your target
-2. `/dgt BackOff` Directs everyone to reset melee, stop casting, etc.
-3. `/dgt ChangeMT *MTNAME*` Changes the current Main Tank  (MT) to the new MT via name
-4. `/dgt ChangeSA *SANAME*` Changes the current Secondary Assist (SA) to the new SA via name
-5. `/dgt ChangeAP *AP*` Changes the autoassist point to int AP
-6. `/dgt DoStaunchRecovery` Tells everyone to hit Staunch Recovery AA
-7. `/dgt DoIntensity` Tells everyone to hit Intensity of the Resolute AA
-8. `/dgt DoServants` Tells everyone to hit Steadfast Servant AA
-9. `/dgt DoInfusion` Tells everyone to hit Infusion of the Faithful AA
-10. `/dgt SetupRaid` A mostly internal or event used event. Describes the raid mode currerntly running, defaults to.. DEFAULT. Calls SetupRaid which pulls from xiris_common INI. Sets lists of group leaders, and DI available clerics
-12. `/dgt RefreshXTarget` Used to manually force raid to refresh their XTarget list.
-13. `/dt MeleeOverride TRUE|FALSE` Used to manually force a toon to start/stop meleeing (ie: casters/priests)
-### xiris_curing.inc
-#### Overview
-XirisBot curing handlers. This library has several events that can be fired via hotkey, or auto cures driven by the curing section in the toon ini files. Note that this file is responsible for a toons self-need-cure checks - something to be familiar with.
-#### Requirements
-mq2cast, mq2dannet, mq2debuffs
-#### Events
-1. `/dt CurerName autoCureMT TRUE` `/dt CurerName autoCureMT FALSE` Toggle to tell specific character to auto cure the MT (clerics mostly)
-2. `/dgt cureGroupPoison 45` Tell the curers in raid to walk through their groups and cure 45 poison counters on whomever has poison counters (will skip toons with no counters)
-3. `/dgt cureGroupCurse 45` Tell the curers in raid to walk through their groups and cure 45 curse counters on whomever has curse counters (will skip toons with no counters)
-4. `/dgt cureGroupDisease 45` Tell the curers in raid to walk through their groups and cure 45 disease counters on whomever has disease counters (will skip toons with no counters)
-5. `/dt CurerName cureMe cureType` Asks a curer to cure requester by type (poison, disease, curse) - curer will determine how many counters.
-### xiris_debuffing.inc
-#### Overview
-XirisBot debuffing handlers. This library has several events that can be fired via hotkey. Much of the debuffing is automatic and is controlled by character ini file.
-#### Requirements
-mq2cast, mq2dannet, mq2debuffs
-#### Events
-1. `/dgt DebuffTarget ${Target.ID}` Will force raid debuffers to cycle through debuffs on target. 
-### xiris_debuffing.inc
-#### Overview
-XirisBot debuffing handlers. This library has several events that can be fired via hotkey. Much of the debuffing is automatic and is controlled by character ini file.
-#### Requirements
-mq2cast, mq2dannet, mq2debuffs
-#### Events
-1. `/dgt DebuffTarget ${Target.ID}` Will force raid debuffers to cycle through debuffs on target. 
-### xiris_events.inc
-#### Overview
-XirisBot event handler(s). This library has several sub libraries. These contain all the handlers for specific raid/mob events, such as MPG trials, or Anguish events. Each of those files is specific to the raid, and should be familiarized before attempting those raids.
-#### Requirements
-*all*
-#### Events
-Many events, all raid specific.
-### xiris_healing.inc
-#### Overview
-XirisBot healing handler. This library is a core library for priest classes.
-#### Requirements
-mq2cast, mq2dannet
-#### Events
-1. `/dgt GroupHeal` Tells every capable class to fire a group heal
-2. `/dgt InterruptON` `/dgt InterruptOFF` Toggles the ability to interrupt heals if no longer necessary (used usually in conjunction with efficiency mode)
-3. `/dgt ChangeHP 85` Changes the MT heal point to provided integer
-4. `/dgt ChangeHPTank 85` Changes the MT heal point to provided integer
-5. `/dgt ChangeHPSelf 85` Changes the Self heal point to provided integer
-6. `/dgt ChangeHpGroup 85` Changes the Group heal point to provided integer
-7. `/dgt HealMode EFFICIENT|DEFAULT` Changes the heal mode (and spells cast) to either default or efficient mode. Efficient recommended for most events if you have many clerics.
-8. `/dt Healer FocusHEALMT_ON|FocusHealMT_OFF` Toggles the healer to only heal self and MT
-9. `/dt Healer HealType 0|1|2|3` Changes the heal type to following:
-    1. /if (${int_heal_mode}==0) /echo \a-wChanging healing \aoTYPE \a-wto \ag0-Self (only)
-    2. /if (${int_heal_mode}==1) /echo \a-wChanging healing \aoTYPE \a-wto \ag1-MT (and self)
-    3. /if (${int_heal_mode}==2) /echo \a-wChanging healing \aoTYPE \a-wto \ag2-Group (and MT, includes self)
-    4. /if (${int_heal_mode}==3) /echo \a-wChanging healing \aoTYPE \a-wto \ag3-GroupOnly (includes self)
-10. `/dgt FireTotem X` where X is the totem group. (Cleric, Druid, Shaman) defined by char ini. Will cause toons in group X (integer) to place their heal totems
-##### CH Events
-1. `/dgt CHStart 1 ${Me.Name} Xiria 30 cleric1,cleric2,cleric3,cleric4` Will start a ch chain with the 4 clerics listed. 3 second delay. Chain key of 1, meaning that chain is index 1, so multiple chains can be run. `CHStart ChainIndex HealTarget BackupTarget Delay [CSV Clerics]`
-2. `/dgt CHStop 1` Will stop the 1 index CHChain
-3. `/dgt CHPause 1` CHChain #1 will pause until resumed
-4. `/dgt CHResume 1` CHChain #1 will resume 
-5. `/dgt CHSwitch 1 Xiria` CHChain #1 will switch to healing Xiria
-
-
-
-
-## 📈 Impact & Metrics
-
-| Metric       | Value                    |
-|--------------|--------------------------|
-| ⭐ Stars      | 4                        |
-| 🍴 Forks      | 1                        |
-| 📦 Releases   | 4 (latest: v1.5.3-stable) |
-| 📁 Commits    | 165+                     |
-| 👀 Watchers   | 2                        |
-
-These metrics demonstrate early adoption, active maintenance, and a stable release cadence—elements recruiters look for in sustainable open-source projects.
-
-## 🤝 Contributing
-
-* Fork the repository and create a new branch for your feature or bugfix.
-* Follow existing coding conventions and document any new INI parameters.
-* Submit a pull request with a clear description, linking to relevant issues.
-* Engage in code reviews or join discussions on the EQEMU forums to share feedback.
-
-## 📜 License & Contact
-
-XirisBot is released under the MIT License.  
-Maintainer: Matthew J Breault (meta53)  
-Email: meta53@example.com
-
-
-Feel free to open issues, request features, or reach out directly for collaboration.
+Keep command names synchronized with their `#EVENT` definitions, document new INI keys, and include a short test description with behavior changes. Avoid committing account credentials, server login information, or private character data.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,116 @@
+# Architecture
+
+## Startup flow
+
+```text
+xiris_bot.mac
+  -> resolves default tanks and heal point
+  -> selects bot_<CLASS>.mac
+  -> routes BER/MNK/ROG to bot_melee.mac
+  -> class macro calls xbot_initialize
+  -> shared libraries load INI-driven lineups and events
+  -> class macro enters MainLoop
+```
+
+## Main-loop priorities
+
+Class loops generally process:
+
+1. Critical and registered events
+2. Tank validity
+3. Curing and healing, where applicable
+4. Auto-assist and engagement state
+5. Class combat actions
+6. AA, burn, and clicky lineups
+7. Target/death validation
+8. Idle utilities, sitting, looting, and downshifts
+
+The exact order differs by class. Healing classes deliberately check health before DPS.
+
+## Shared libraries
+
+| Include | Responsibility |
+|---|---|
+| `xiris_common.inc` | Initialization, targeting, engagement, common state, utilities |
+| `xiris_events.inc` | Registration and dispatch of event sets |
+| `xiris_spell_routines.inc` | Common casting execution and result handling |
+| `xiris_casting.inc` | Nukes, quick nukes, AE nukes, DoTs, stuns, resist filters |
+| `xiris_healing.inc` | Heal selection, group health, rez, CH chains |
+| `xiris_curing.inc` | Self/group/tank cure decisions and coordination |
+| `xiris_buffing.inc` | Raid, character, single-target, and combat buffs |
+| `xiris_buffing_lines.inc` | Reusable buff-line definitions |
+| `xiris_debuffing.inc` | Debuff and slow lineups |
+| `xiris_burn.inc` | Burn, AA, and clicky lineups |
+| `xiris_melee.inc` | Melee abilities, stick, positioning, melee events |
+| `xiris_movement.inc` | Follow, navigation, waypoints, and camps |
+| `xiris_offtank.inc` | Offtank selection and control |
+| `xiris_pets.inc` | Pet creation, equipment, buffs, and attacks |
+| `xiris_looting.inc` | Loot selection, corpse handling, selling, and hand-ins |
+| `xiris_charm.inc` | Charm selection and control |
+| `xiris_exclude.inc` | Target exclusions and alerts |
+
+## Event system
+
+Events are declared with `#EVENT`, grouped into dispatcher subroutines, and registered during initialization as background, raid, class, or rapid event sets.
+
+When adding a command:
+
+1. Add all required chat/DanNet patterns.
+2. Add an `EVENT_<name>` handler.
+3. Add `/doevents <name>` to the correct event-set subroutine.
+4. Register the event set with an accurate count.
+5. Document the command and its arguments.
+6. Test tell, raid/group chat, and DanNet delivery forms that the pattern claims to support.
+
+Rapid events are used where reaction time matters during casting or other waits. Avoid moving ordinary maintenance work into rapid dispatch.
+
+## Raid events
+
+`xiris_events.inc` includes encounter libraries for Gates of Discord, Omens of War, Epic encounters, and Depths of Darkhollow. Initialization selects relevant sets from zone short names.
+
+Raid handlers may:
+
+- Duck or interrupt casts
+- Move with MQ2Nav
+- Change targets
+- Change healing or burn modes
+- React to boss emotes
+- Coordinate group assignments
+
+Because these reactions are encounter-sensitive, test changes in the target zone and preserve the original emote text.
+
+## INI-driven lineups
+
+Several systems construct dynamic variables from numbered INI records. A typical flow is:
+
+```text
+read <TYPE>_Total
+for each numbered entry
+  split pipe-delimited properties
+  declare <TYPE>_<index> fields
+main loop scans the resulting lineup
+```
+
+Changing a template field order requires coordinated updates to every affected character INI.
+
+## Adding a class behavior
+
+Prefer extending a shared library when behavior is common to multiple classes. Keep class macros focused on ordering and class-only events.
+
+For a new class-specific action:
+
+1. Add configuration to the class INI.
+2. Initialize variables in the class macro or relevant shared library.
+3. Add a guarded subroutine with cheap early returns.
+4. Place its call according to gameplay priority.
+5. Avoid blocking `/delay` calls in the main loop.
+6. Pump rapid/raid events during unavoidable waits.
+
+## Performance conventions
+
+- Cache values that remain stable for the current target.
+- Timer-gate full AA, item, inventory, radius, and group scans.
+- Keep death, emergency healing, curing, and rapid events responsive.
+- Avoid synchronous DanNet waits in the main loop.
+- Keep verbose logging disabled during normal raid operation.
+- Use `[PERFORMANCE] Stats=TRUE` temporarily when measuring scan frequency.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,235 @@
+# Command reference
+
+XirisBot commands are chat/event messages, not conventional slash-command binds. Send the command text through a channel recognized by its `#EVENT` patterns.
+
+Common delivery forms used by this repository:
+
+```text
+/rs <command>             raid chat
+/gs <command>             group chat
+/dt Character <command>   one DanNet peer
+/dgt <command>            configured DanNet group
+/dgza <command>           connected peers in the current zone
+```
+
+DanNet scope aliases can vary by build and local configuration. Verify them before issuing movement or combat commands raid-wide.
+
+## Combat control
+
+| Command text | Purpose | Example |
+|---|---|---|
+| `KillMob <id> <name> <time>` | Engage an NPC by spawn ID | `/rs KillMob ${Target.ID} "${Target.CleanName}" ${Time.Time24}` |
+| `BackOff` | Disengage, stop attacks/casts, and reset combat state | `/rs BackOff` |
+| `AutoAssist <value>` | Toggle or modify auto-assist behavior | `/dgt AutoAssist TRUE` |
+| `ChangeMT <name>` | Change the watched primary tank | `/dgt ChangeMT Xiris` |
+| `ChangeAP <percent>` | Change assist threshold | `/dgt ChangeAP 98` |
+| `MeleeOverride TRUE|FALSE` | Force melee behavior for one character | `/dt Xanshia MeleeOverride FALSE` |
+| `ForceNamed TRUE|FALSE` | Override named-target classification | `/dgt ForceNamed TRUE` |
+| `RiposteDisc` | Request configured riposte discipline | `/dgt RiposteDisc` |
+| `UpdateStick <args>` | Change melee stick command | `/dt Ophidia UpdateStick behind 10` |
+
+Always validate `${Target.ID}` before broadcasting `KillMob`.
+
+## Burns and veteran abilities
+
+| Command text | Purpose |
+|---|---|
+| `BurnOnAll` | Enable the full configured burn lineup |
+| `BurnOn1` | Enable burn cohort 1 |
+| `BurnOn2` | Enable burn cohort 2 |
+| `BurnOff` | Disable burn mode |
+| `DoStaunchRecovery` | Request Staunch Recovery |
+| `DoIntensity` | Request Intensity of the Resolute |
+| `DoServants` | Request Steadfast Servant |
+
+Examples:
+
+```text
+/rs BurnOnAll
+/rs BurnOff
+/dgt DoStaunchRecovery
+```
+
+`ShortBurn1`, `ShortBurn2`, `LongBurn1`, `LongBurn2`, and `MaximumBurn` are declared by the burn library but should be verified against their handlers and current character lineups before operational use.
+
+## Movement
+
+| Command text | Purpose | Example |
+|---|---|---|
+| `FollowMe /type|NAV` | Follow sender using MQ2Nav | `/rs FollowMe /type|NAV` |
+| `FollowMe /type|STICK` | Follow sender using stick | `/rs FollowMe /type|STICK` |
+| `NavStop` | Stop navigation/following | `/rs NavStop` |
+| `MoveTo <arguments>` | Move to supplied location/target data | Encounter-specific |
+| `NavToWP <waypoint>` | Navigate to recorded waypoint | `/rs NavToWP westwall` |
+| `CreateCamp <name>` | Create/set camp through the movement library | `/rs CreateCamp raidcamp` |
+
+Record and test waypoints locally before broadcasting `NavToWP`.
+
+## Buffing and damage shields
+
+| Command text | Purpose |
+|---|---|
+| `doRaidBuffs ALL` | Run configured raid-wide buffing |
+| `doSingleTargetBuffs <name>` | Apply configured single-target buffs |
+| `doCharBuffs <name>` | Buff a specified character |
+| `NoDS` | Disable/use removal behavior for damage shields |
+| `YesDS` | Enable damage shields |
+| `RemoveBuff <name>` | Remove a named buff |
+| `RemoveAllBuffs` | Remove all removable buffs handled by the routine |
+
+Examples:
+
+```text
+/rs doRaidBuffs ALL
+/dgt doCharBuffs Xiris
+/dgt NoDS
+/dgt RemoveBuff Circle of Fireskin
+```
+
+## Casting and debuffing
+
+| Command text | Purpose |
+|---|---|
+| `DebuffTarget <id>` | Force configured debuffers to process a target |
+| `SlowTarget <id>` | Force a slow attempt |
+| `ResistTypes <list>` | Limit enabled resist types |
+| `UseFastOnly ON|OFF` | Toggle quick-nuke-only behavior where configured |
+
+Examples:
+
+```text
+/rs DebuffTarget ${Target.ID}
+/rs SlowTarget ${Target.ID}
+/dgt ResistTypes fire|magic
+/dgt UseFastOnly ON
+```
+
+## Healing
+
+| Command text | Purpose |
+|---|---|
+| `DoGroupHeal` | Request configured group-heal actions |
+| `InterruptON` / `InterruptOFF` | Enable or disable heal interruption |
+| `ChangeHP <percent>` | Change general heal threshold |
+| `changeHPTank <percent>` | Change tank threshold |
+| `changeHPSelf <percent>` | Change self threshold |
+| `changeHPGroup <percent>` | Change group threshold |
+| `HealMode DEFAULT|EFFICIENT` | Select healing spell strategy |
+| `HealType 0|1|2|3` | Select healing coverage |
+| `FocusHealMTOn` / `FocusHealMTOff` | Toggle focus on self and watched tank |
+| `FireTotem <group>` | Fire configured priest totem group |
+| `FireRegen <group>` | Fire configured regeneration group |
+
+Heal types:
+
+| Value | Coverage |
+|---|---|
+| `0` | Self only |
+| `1` | Watched tank and self |
+| `2` | Group, watched tank, and self |
+| `3` | Group only, including self |
+
+Examples:
+
+```text
+/dgt HealMode EFFICIENT
+/dt Xanshia HealType 1
+/dgt changeHPTank 80
+/dt Xanshia FocusHealMTOn
+```
+
+## Complete Heal chains
+
+```text
+/dgt CHStart <chain-index> <target> <backup> <delay> <cleric1,cleric2,...>
+/dgt CHStop <chain-index>
+/dgt CHPause <chain-index>
+/dgt CHResume
+/dgt CHSwitch <chain-index> <new-target>
+```
+
+Example:
+
+```text
+/dgt CHStart 1 Xiris Xiria 30 Clericone,Clerictwo,Clericthree,Clericfour
+```
+
+The delay units and cleric order are interpreted by the existing healing routine. Test a new chain outside combat.
+
+## Curing
+
+| Command text | Purpose |
+|---|---|
+| `cureGroupPoison <counters>` | Inspect and cure group poison counters |
+| `cureGroupDisease <counters>` | Inspect and cure group disease counters |
+| `cureGroupCurse <counters>` | Inspect and cure group curse counters |
+| `cureMe <type>` | Ask a specific curer to cure the sender |
+| `AutoCureMTOn` / `AutoCureMTOff` | Toggle proactive watched-tank curing |
+| `ResetGroupCurer` | Reset cure assignment state |
+| `fireNadox` | Request configured Nadox action |
+
+Examples:
+
+```text
+/dgt cureGroupPoison 45
+/dgt cureGroupDisease 45
+/dgt cureGroupCurse 45
+/dt Xanshia AutoCureMTOn
+/dt Xanshia cureMe curse
+```
+
+## Looting
+
+| Command text | Purpose |
+|---|---|
+| `looton ALL` | Enable all configured loot types |
+| `looton QUEST` | Enable configured quest loot only |
+| `lootoff` | Disable automated looting |
+| `lootrefresh` | Reload/refresh loot state |
+| `DoHideCorpses` | Hide corpses according to routine |
+| `DoHideLooted` | Hide looted corpses |
+| `LootYourself` | Attempt self-corpse looting |
+| `selltovendor` | Run configured vendor selling |
+
+Examples:
+
+```text
+/dt Looter looton ALL
+/dt Looter looton QUEST
+/dt Looter lootoff
+/dgt DoHideLooted
+```
+
+## Offtanking
+
+```text
+/dt TankName OfftankOn
+/dt TankName OfftankOff
+/dt TankName OfftankRadius 75
+/dt TankName DIOn
+/dt TankName DIOff
+```
+
+Offtanking is primarily intended for plate tanks. Monitor the first pulls after changing its radius.
+
+## Charm
+
+```text
+/dt Enchanter CharmON
+/dt Enchanter CharmNPCByID ${Target.ID}
+/dt Enchanter CharmNPCByName "an npc name"
+/dt Enchanter CharmOFF
+```
+
+Charm support is specialized and should be tested for the exact encounter.
+
+## Raid setup and utilities
+
+```text
+/dgt SetupRaid DEFAULT
+/dgt RefreshXTarget
+/dgt CheckNaked
+/dgt fixCorpses
+```
+
+Raid-specific includes register many additional encounter commands. Those are implementation controls, not general-purpose commands; review the corresponding `xiris_events_raid_*.inc` before using them.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,131 @@
+# Configuration
+
+## Character INI naming
+
+The active INI is selected from the character's class short name and clean name:
+
+```text
+xiris_class_ini/BOT_<CLASS>_<Character>.ini
+```
+
+Examples:
+
+```text
+xiris_class_ini/BOT_WAR_Xiris.ini
+xiris_class_ini/BOT_CLR_Xanshia.ini
+xiris_class_ini/BOT_WIZ_Xiexi.ini
+```
+
+Names and case should match `${Me.Class.ShortName}` and `${Me.CleanName}`.
+
+## Loader arguments
+
+```text
+/mac xiris_bot <tank1> <tank2> <tank3> <tank-heal-point> "<auto-assist>,<assist-at>"
+```
+
+| Argument | Meaning | Example |
+|---|---|---|
+| `tank1` | Primary tank watched by the bot | `Xiris` |
+| `tank2` | Secondary replacement tank | `Xiria` |
+| `tank3` | Third replacement tank | `Xirea` |
+| `tank-heal-point` | Normal tank heal threshold | `85` |
+| `auto-assist` | Whether the bot queries the tank target automatically | `FALSE` |
+| `assist-at` | Target HP threshold used by assist behavior | `98` |
+
+Missing values fall back to INI defaults. Quote the comma-separated assist argument.
+
+## Common configuration areas
+
+Character files differ by class, but commonly contain these behavior families:
+
+| Area | Controls |
+|---|---|
+| `DEFAULT_SETTINGS` | Tank defaults, assist point, spell set, sitting and utility behavior |
+| `Heal_Points` | Tank, self, group, frantic, HoT, and stop-cast thresholds |
+| `NUKE`, `QNUKE`, `AENUKE` | Spell order, HP windows, mana floors, named-only behavior |
+| `DOT` | DoT order, recast timing, HP windows, resist rules |
+| `DEBUFF` | Debuff order, forced/named behavior, HP windows |
+| `AA` | Offensive and defensive AA lineups and triggers |
+| `BURN` | Burn sequence and cohort behavior |
+| `CLICKY` | Item click order, type, trigger, and named restrictions |
+| Buff sections | Out-of-combat, combat, single-target, and buff-line definitions |
+| Pet sections | Pet summoning, buffs, weapons, and attack behavior |
+| Cure sections | Cure spells, thresholds, assignments, and auto-cure behavior |
+
+Use an existing INI for the same class as the schema reference. The macro frequently builds dynamic variables from numbered entries; totals must agree with the entries present.
+
+## Numbered lineup pattern
+
+Many sections use a total followed by numbered pipe-delimited records:
+
+```ini
+[AA]
+AA_Total=2
+AA_1=Example Offensive AA|OFFENSE|TRUE|FALSE|98|1|FALSE
+AA_2=Example Defensive AA|DEFENSE|TRUE|FALSE|100|1|FALSE
+```
+
+Field order is defined by the corresponding template in the shared include. For example, AA, burn, and clicky templates live in `xiris_common/xiris_burn.inc`. Copying a known-good entry is safer than guessing field order.
+
+## Spell sets
+
+Several routines temporarily load named spell sets. At minimum, classes that buff should normally have:
+
+- `default`: normal combat spell arrangement
+- `buff`: raid-buff spell arrangement
+
+Specialized class or event routines may require additional sets. Search the class macro and character INI for `memspellset` before deploying a copied configuration.
+
+## Shared INIs
+
+| File | Purpose |
+|---|---|
+| `xiris_common/xiris_common.ini` | Shared raid and common definitions |
+| `xiris_common/xiris_healing.ini` | Shared healing definitions |
+| `xiris_common/xiris_loot_list.ini` | Loot policy |
+| `xiris_common/xiris_exclude.ini` | Excluded targets |
+| `xiris_common/xiris_casting_resists.ini` | Resist-related casting definitions |
+| `xiris_common/xiris_damageshields.ini` | Damage shield definitions |
+| `xiris_common/xiris_pull_zoneinfo.ini` | Puller zone data |
+
+## Loot entries
+
+Loot rules are pipe-delimited:
+
+```ini
+Loot1=Minor Muramite Rune|QUEST|*|*|!|Aergia|F
+```
+
+Fields:
+
+1. Item name
+2. Type, such as `VENDOR`, `TRADE`, or `QUEST`
+3. Desired count, or `*`
+4. Allowed class short names, or `*`
+5. Excluded character, or `!`
+6. Required character, or `*`
+7. Beep flag, `T` or `F`
+
+Test loot changes on one designated looter. Incorrect loot rules can leave items behind or assign them incorrectly.
+
+## Performance diagnostics
+
+The common initializer recognizes an optional section:
+
+```ini
+[PERFORMANCE]
+Debug=FALSE
+VerboseCombat=FALSE
+Stats=FALSE
+```
+
+Set `Stats=TRUE` temporarily to print 60-second combat-loop and scan counters. `VerboseCombat=TRUE` enables detailed burn diagnostics and should normally remain off on large crews.
+
+## Safe editing workflow
+
+1. Change one character INI.
+2. Restart that character's macro.
+3. Test idle, engage, disengage, death, zone, and recovery behavior.
+4. Copy the verified pattern to comparable characters.
+5. Commit the configuration change with the code version it requires.

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -1,0 +1,227 @@
+# Recommended hotkeys
+
+These examples are designed for the primary tank or raid controller. Replace character names, thresholds, waypoints, and DanNet scopes to match your crew.
+
+## Page 1: core control
+
+### Start bots
+
+```text
+Line 1: /dgza /mac xiris_bot ${Me.Name} Xiria Xirea 85 "FALSE,98"
+```
+
+### Engage
+
+```text
+Line 1: /multiline ; /rs KillMob ${Target.ID} "${Target.CleanName}" ${Time.Time24} ; /attack on
+```
+
+### Emergency back off
+
+```text
+Line 1: /rs BackOff
+Line 2: /rs NavStop
+Line 3: /attack off
+```
+
+### Follow with Nav
+
+```text
+Line 1: /rs FollowMe /type|NAV
+```
+
+### Follow with stick fallback
+
+```text
+Line 1: /rs FollowMe /type|STICK
+```
+
+### Stop movement
+
+```text
+Line 1: /rs NavStop
+```
+
+## Page 2: targets and positioning
+
+### Change main tank to me
+
+```text
+Line 1: /dgt ChangeMT ${Me.CleanName}
+```
+
+### Change main tank to target
+
+Use only while targeting the intended player:
+
+```text
+Line 1: /dgt ChangeMT ${Target.CleanName}
+```
+
+### Navigate to waypoint
+
+```text
+Line 1: /rs NavToWP raidcamp
+```
+
+### Force debuffs
+
+```text
+Line 1: /rs DebuffTarget ${Target.ID}
+```
+
+### Force slow
+
+```text
+Line 1: /rs SlowTarget ${Target.ID}
+```
+
+## Page 3: burns and recovery
+
+### Full burn
+
+```text
+Line 1: /rs BurnOnAll
+```
+
+### Stop burn mode
+
+```text
+Line 1: /rs BurnOff
+```
+
+### Cohort burns
+
+```text
+Line 1: /rs BurnOn1
+```
+
+Create a separate button for `BurnOn2` if cohorts alternate.
+
+### Veteran recovery
+
+```text
+Line 1: /dgt DoStaunchRecovery
+```
+
+## Page 4: healing and curing
+
+### Efficient healing
+
+```text
+Line 1: /dgt HealMode EFFICIENT
+```
+
+### Default healing
+
+```text
+Line 1: /dgt HealMode DEFAULT
+```
+
+### Raise tank heal point
+
+```text
+Line 1: /dgt changeHPTank 90
+```
+
+### Restore tank heal point
+
+```text
+Line 1: /dgt changeHPTank 80
+```
+
+### Cure raid groups
+
+```text
+Line 1: /dgt cureGroupPoison 45
+Line 2: /dgt cureGroupDisease 45
+Line 3: /dgt cureGroupCurse 45
+```
+
+### Force group heal
+
+```text
+Line 1: /dgt DoGroupHeal
+```
+
+## Page 5: preparation and cleanup
+
+### Raid buffs
+
+```text
+Line 1: /rs doRaidBuffs ALL
+```
+
+### Disable damage shields
+
+```text
+Line 1: /dgt NoDS
+```
+
+### Enable damage shields
+
+```text
+Line 1: /dgt YesDS
+```
+
+### Enable looter
+
+```text
+Line 1: /dt Looter looton ALL
+```
+
+### Quest loot only
+
+```text
+Line 1: /dt Looter looton QUEST
+```
+
+### Disable looter
+
+```text
+Line 1: /dt Looter lootoff
+```
+
+## Targeted-role examples
+
+### Tank offtank toggle
+
+```text
+Line 1: /dt Xiria OfftankOn
+Line 2: /dt Xiria OfftankRadius 75
+```
+
+Create a paired off button:
+
+```text
+Line 1: /dt Xiria OfftankOff
+```
+
+### Cleric watches a different tank
+
+```text
+Line 1: /dt Xanshia ChangeMT Xiria
+Line 2: /dt Xanshia AutoCureMTOn
+Line 3: /dt Xanshia HealType 1
+```
+
+### Fast-nuke mode
+
+```text
+Line 1: /dgt UseFastOnly ON
+```
+
+Paired off button:
+
+```text
+Line 1: /dgt UseFastOnly OFF
+```
+
+## Hotkey design guidance
+
+- Put `BackOff` and `NavStop` on an easy-to-reach page shared by every tank UI.
+- Use distinct colors for engage, movement, burn, and emergency controls.
+- Prefer spawn IDs over names for NPC combat commands.
+- Use `/dt` for dangerous role-specific commands and broader scopes only when intentional.
+- Do not combine `KillMob` with movement or burn commands until each works independently.
+- Keep paired ON/OFF buttons adjacent.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,107 @@
+# Installation
+
+## Requirements
+
+XirisBot targets a RoF2 EverQuest client with a compatible MacroQuest/MQNext build. The exact plugin package depends on your distribution, but the framework uses these capabilities:
+
+| Plugin | Used for |
+|---|---|
+| MQ2DanNet | Peer messaging and remote queries |
+| MQ2Cast | Spell, AA, discipline, and item casting |
+| MQ2Nav | Mesh-based following and navigation |
+| MQ2MoveUtils | Stick-based movement and melee positioning |
+| MQ2Exchange | Equipment and weapon-set changes |
+| MQ2Debuffs | Debuff and cure-counter inspection |
+| MQ2WorstHurt | Priority healing selection |
+| MQ2Medley | Bard song rotation and queued casts |
+
+Some classes or encounters use only a subset. Loading every plugin used by your raid is the simplest setup.
+
+## Install the files
+
+Place the repository contents in the MacroQuest macros directory so these paths exist together:
+
+```text
+Macros/xiris_bot.mac
+Macros/bot_clr.mac
+Macros/xiris_common/xiris_common.inc
+Macros/xiris_class_ini/BOT_CLR_Character.ini
+```
+
+Do not flatten `xiris_common` or `xiris_class_ini`; includes and INI lookups use those relative paths.
+
+## Load plugins
+
+From the MacroQuest console, load the plugins available in your build:
+
+```text
+/plugin mq2dannet
+/plugin mq2cast
+/plugin mq2nav
+/plugin mq2moveutils
+/plugin mq2exchange
+/plugin mq2debuffs
+/plugin mq2worsthurt
+```
+
+Bards additionally need:
+
+```text
+/plugin mq2medley
+```
+
+Use `/plugin list` to verify the loaded names. Plugin spelling and availability vary slightly between MacroQuest distributions.
+
+## MQ2Nav meshes
+
+MQ2Nav requires a usable mesh for every zone in which navigation commands will run. Put meshes in the directory expected by your MQ2Nav build and test locally:
+
+```text
+/nav target
+/nav stop
+```
+
+Never test raid-wide navigation until local pathing works reliably.
+
+## Bard medleys
+
+Define medleys in the character-specific MacroQuest INI. The medley names must match the values selected by the bard macro and character INI.
+
+```ini
+[MQ2Medley]
+Delay=3
+Quiet=1
+Debug=0
+
+[MQ2Medley-tank]
+song1=Niv's Harmonic^18^1
+song2=Guardian Rhythms^18^1
+song3=Verse of Vesagran^18^1
+song4=War March of Muram^18^1
+song5=Psalm of Mystic Shielding^18^1
+```
+
+## First-character test
+
+1. Copy the closest character INI and rename it correctly.
+2. Confirm configured spells, AAs, disciplines, and items exist on that character.
+3. Start without auto-assist:
+
+   ```text
+   /mac xiris_bot MainTank SecondTank ThirdTank 85 "FALSE,98"
+   ```
+
+4. Watch the MQ console for missing plugin, undefined variable, spell, or INI errors.
+5. Test `FollowMe`, `NavStop`, `KillMob`, and `BackOff` before starting the entire crew.
+
+## DanNet setup
+
+XirisBot runs `/dnet fullnames off` during initialization so event senders use short character names. Confirm peers are visible with your build's DanNet information command before using `/dgza`, `/dgt`, or `/dt` hotkeys.
+
+## Updating
+
+Before pulling or replacing files:
+
+- Commit or back up character INIs.
+- Review changes to shared includes and event patterns.
+- Test one healer, one caster, and one melee character before raid-wide deployment.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,110 @@
+# Troubleshooting
+
+## Macro does not select the expected class file
+
+Check `${Me.Class.ShortName}` and confirm the corresponding `bot_<class>.mac` exists. Berserkers, monks, and rogues intentionally load `bot_melee.mac`.
+
+## Character INI is not found
+
+Verify the exact path and naming convention:
+
+```text
+xiris_class_ini/BOT_<CLASS>_<Character>.ini
+```
+
+Use the clean character name, not a server-qualified DanNet name.
+
+## Undefined variable during initialization
+
+Typical causes:
+
+- A numbered total is larger than the entries present.
+- A copied record has the wrong number of pipe-delimited fields.
+- The INI belongs to a different code version.
+- A required spell/item/AA variable was left empty.
+
+Compare the section with a known-good INI for the same class and the template in the owning include.
+
+## Commands appear in chat but bots do nothing
+
+1. Confirm the macro is running on the recipient.
+2. Confirm the command spelling and argument order in [Commands](commands.md).
+3. Verify `/dnet fullnames off` was applied during initialization.
+4. Try a direct `/dt Character ...` message.
+5. Check whether the event set is registered for that class or zone.
+6. Check whether the handler immediately rejects the character because of class, mode, range, or readiness.
+
+## Auto-assist does not engage
+
+- Confirm `AutoAssist` is enabled in the loader arguments or command state.
+- Confirm the primary tank name is correct and is a visible DanNet peer.
+- Confirm the tank has a valid NPC target.
+- Check the assist HP threshold.
+- Use an explicit `KillMob` command to separate assist-query problems from combat problems.
+
+## Navigation does not start or characters get stuck
+
+- Verify MQ2Nav is loaded.
+- Test `/nav target` locally.
+- Confirm the zone mesh exists and covers both endpoints.
+- Use `NavStop`, reposition manually, and retry.
+- Use `FollowMe /type|STICK` as a fallback where appropriate.
+
+## Healer reacts but chooses no spell
+
+Check:
+
+- Heal type and heal mode
+- Tank/self/group thresholds
+- Current spell set and memorized gems
+- Mana requirements
+- Target range
+- Configured spell names for the server era
+- Stop-cast and HoT timers
+
+Use `[PERFORMANCE] VerboseCombat=TRUE` only when its additional output is useful; it does not trace every healing decision.
+
+## Cure requests are ignored
+
+- Confirm MQ2Debuffs is loaded.
+- Confirm cure use is enabled for the character.
+- Verify cure type and counter threshold.
+- Confirm the assigned curer is online, in range, and has the configured cure memorized or available.
+- Reset cure coordination with `ResetGroupCurer` if state appears stale.
+
+## Clickies or AAs never fire
+
+- Confirm the lineup total and numbered entries.
+- Confirm the configured item name exactly matches the inventory item.
+- Check `Use`, type, named-only, HP window, and trigger fields.
+- Clicky IDs refresh periodically, but restart the macro after major equipment or configuration changes.
+
+## Excessive CPU or command lag
+
+Temporarily enable:
+
+```ini
+[PERFORMANCE]
+Stats=TRUE
+VerboseCombat=FALSE
+```
+
+Compare the reported combat loops and lineup scans across classes. Also check for:
+
+- Missing timers around custom loops
+- Repeated navigation failures
+- Chat/log spam
+- Huge AA/clicky/debuff lineups
+- Encounter handlers active in the wrong zone
+- Multiple macros controlling the same character
+
+## Safe recovery sequence
+
+From the controller:
+
+```text
+/rs BackOff
+/rs NavStop
+```
+
+Then stop or restart only the affected character's macro. Avoid restarting the full raid until the local failure is understood.


### PR DESCRIPTION
## What changed

- replace the oversized, stale README with a focused project overview and quick start
- add dedicated installation, configuration, command reference, hotkey, architecture, and troubleshooting guides
- document loader arguments, INI naming, shared configuration, supported classes, plugin requirements, and performance diagnostics
- add copy-ready hotkey examples for combat, movement, burns, healing, curing, buffing, looting, and role-specific control
- remove stale project metrics, placeholder contact information, duplicate sections, malformed links, and encoding artifacts

## Why

The previous README mixed setup, architecture, command reference, operational advice, and outdated project metadata in one long page. Important commands and configuration conventions were difficult to discover, and several examples no longer matched the current repository layout.

## Impact

New users get a shorter onboarding path, while operators and contributors have task-specific reference pages. No macro behavior or runtime configuration is changed.

## Validation

- `git diff --cached --check`
- verified all local Markdown links resolve
- cross-checked major documented commands against their registered `#EVENT` patterns
